### PR TITLE
javascript changes in PunkAveFileUploader

### DIFF
--- a/Resources/public/js/FileUploader.js
+++ b/Resources/public/js/FileUploader.js
@@ -13,7 +13,7 @@ function PunkAveFileUploader(options)
   
   self.uploading = false;
   
-  self.errorCallback = 'errorCallback' in options ? options.errorCallback : function( info ) { },
+  self.errorCallback = 'errorCallback' in options ? options.errorCallback : function( info ) { if (window.console && console.log) { console.log(info) } },
 
   self.addExistingFiles = function(files)
   {


### PR DESCRIPTION
- trailing comma fix for ie
- errorCallback in options 
- change initial existing files to use the viewUrl instead of the uploadUrl. 
  (the download links for existing items did not work with the uploadUrl)
