### PR TITLE
Rsync alternative for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Let's assume there is an edit.html.twig template associated with the edit action
     $(function() {
         new PunkAveFileUploader({ 
             'uploadUrl': {{ path('upload', { editId: editId }) | json_encode | raw }},
-            'viewUrl': {{ '/uploads/tmp/attachments/' ~ editId | json_encode | raw }},
+            'viewUrl': {{ '/uploads/tmp/attachments/#{editId}' | json_encode | raw }},
             'el': '.file-uploader',
             'existingFiles': {{ existingFiles | json_encode | raw }},
             'delaySubmitWhileUploading': '.edit-form'

--- a/Services/FileManager.php
+++ b/Services/FileManager.php
@@ -61,14 +61,14 @@ class FileManager
         }
     	if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
         {
-			//Running on Windows
-			system('rd /s/q ' . escapeshellarg($folder));
-		}
+	   //Running on Windows
+	   system('rd /s/q ' . escapeshellarg($folder));
+	}
         else
         {
-			//Not running on Windows. Hoping it's a Linux
-    		system("rm -rf " . escapeshellarg($folder));
-		}
+	   //Not running on Windows. Hoping it's a Linux
+    	   system("rm -rf " . escapeshellarg($folder));
+	}
     }
 
     /**
@@ -115,19 +115,19 @@ class FileManager
             {
                 throw new \Exception("to_folder does not exist");
             }
-			if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
+            if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
             {
-				//Running on Windows
-				system("robocopy /Mir /NP /NDL /NFL /NJH /NJS " . escapeshellarg($from . '/') . " " . escapeshellarg($to), $result);
-
-			}
+                //Running on Windows
+                system("robocopy /Mir /NP /NDL /NFL /NJH /NJS " . escapeshellarg($from . '/') . " " . escapeshellarg($to), $result);
+                $kk=1;
+            }
             else
             {
-				//Not running on Windows. Hoping it's a Linux
-    			system("rsync -a --delete " . escapeshellarg($from . '/') . " " . escapeshellarg($to), $result);
-			}
-			
-            if ($result !== 1)
+                 //Not running on Windows. Hoping it's a Linux
+                 system("rsync -a --delete " . escapeshellarg($from . '/') . " " . escapeshellarg($to), $result);
+                 $kk=0;
+            }		
+            if ($result !== $kk)
             {	
                 throw new \Exception("Sync failed");
             }
@@ -135,14 +135,14 @@ class FileManager
             {
                 if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
                 {
-					//Running on Windows
-					system('rd /s/q ' . escapeshellarg($from));
-				}
+                    //Running on Windows
+                    system('rd /s/q ' . escapeshellarg($from));
+                }
                 else
                 {
-					//Not running on Windows. Hoping it's a Linux
-    				system("rm -rf " . escapeshellarg($from));
-				}
+                    //Not running on Windows. Hoping it's a Linux
+                    system("rm -rf " . escapeshellarg($from));
+                }
             }
         }
         else

--- a/Services/FileManager.php
+++ b/Services/FileManager.php
@@ -59,7 +59,16 @@ class FileManager
         {
             throw \Exception("folder option looks empty, bailing out");
         }
-        system("rm -rf " . escapeshellarg($folder));
+    	if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
+        {
+			//Running on Windows
+			system('rd /s/q ' . escapeshellarg($folder));
+		}
+        else
+        {
+			//Not running on Windows. Hoping it's a Linux
+    		system("rm -rf " . escapeshellarg($folder));
+		}
     }
 
     /**
@@ -106,14 +115,34 @@ class FileManager
             {
                 throw new \Exception("to_folder does not exist");
             }
-            system("rsync -a --delete " . escapeshellarg($from . '/') . " " . escapeshellarg($to), $result);
-            if ($result !== 0)
+			if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
             {
+				//Running on Windows
+				system("robocopy /Mir /NP /NDL /NFL /NJH /NJS " . escapeshellarg($from . '/') . " " . escapeshellarg($to), $result);
+
+			}
+            else
+            {
+				//Not running on Windows. Hoping it's a Linux
+    			system("rsync -a --delete " . escapeshellarg($from . '/') . " " . escapeshellarg($to), $result);
+			}
+			
+            if ($result !== 1)
+            {	
                 throw new \Exception("Sync failed");
             }
             if (isset($options['remove_from_folder']) && $options['remove_from_folder'])
             {
-                system("rm -rf " . escapeshellarg($from));
+                if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
+                {
+					//Running on Windows
+					system('rd /s/q ' . escapeshellarg($from));
+				}
+                else
+                {
+					//Not running on Windows. Hoping it's a Linux
+    				system("rm -rf " . escapeshellarg($from));
+				}
             }
         }
         else


### PR DESCRIPTION
For Windows, rsync is replaced with robocopy to mirror the temp directory into the permanent one. And used Windows commands to delete directories and files.

Not sure if the OS check is safe. Might need further testing. On Windows, it works well for me.
