### PR TITLE
Fixed two problems

### DIFF
--- a/Resources/views/Default/templates.html.twig
+++ b/Resources/views/Default/templates.html.twig
@@ -1,3 +1,4 @@
+{% spaceless %}
 {# Contains Underscore templates for the file uploader. #}
 {# As long as the data-* attributes stay on the appropriate elements #}
 {# you can override the markup pretty extensively in a local version #}
@@ -42,4 +43,4 @@
         </div>
     </li>
 </script>
-
+{% endspaceless %}

--- a/Services/FileUploader.php
+++ b/Services/FileUploader.php
@@ -103,7 +103,6 @@ class FileUploader
         }
 
         @mkdir($uploadDir, 0777, true);
-
         $upload_handler = new \PunkAve\FileUploaderBundle\BlueImp\UploadHandler(
             array(
                 'upload_dir' => $uploadDir, 
@@ -111,7 +110,7 @@ class FileUploader
                 'script_url' => $options['request']->getUri(),
                 'image_versions' => $sizes,
                 'accept_file_types' => $allowedExtensionsRegex,
-                'max_number_of_files' => $this->options['max_number_of_files'],
+                'max_number_of_files' => $options['max_number_of_files'],
             ));
 
         // From https://github.com/blueimp/jQuery-File-Upload/blob/master/server/php/index.php


### PR DESCRIPTION
@pmliju was having a jQuery problem with:

**_Error: Syntax error, unrecognized expression: <li data-name="db-config (14).ini" class="thumbnail">**_

```
    <div class="caption">
        <span class="filename">db-config (14).ini</span>
        <a rel="tooltip" title="Download Original" class="download thumbnail-action btn=" target="download" href="&#x2F;uploads&#x2F;.&#x2F;&#x2F;originals&#x2F;db-config%20%2814%29.ini"><i class="icon-download"></i></a>
        <a rel="tooltip" title="Delete" data-action="delete" class="delete thumbnail-action btn" href="#delete">
           <i class="icon-trash" style="background-position:-456px 0;"></i>
        </a>
    </div>
</li>
```

This problem was occurring because of the whitespace in the contents of the file. Somehow this error doesn't show up for everyone (for me it worked) but since adding the {% spacess %} block doesn't harm anything it doesn't matter and fixed it for @pmliju.

Next to that, also with this pull-request it's possible to set the maximum_number_files as a setting when you are calling handleFileUpload method from the service.
