### PR TITLE
Update README.md to include symfony 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Requirements
 Installation
 ============
 
-Symfony 2.1
+Symfony 2.0
 -----------
 1) Add the following line to your Symfony2 deps file:
     
@@ -53,7 +53,12 @@ Symfony 2.2
 1) Add the following line to your composer.json require block:
     "punkave/symfony2-file-uploader-bundle": "dev-master"
 
-    a) Symfony 2.2 Standard has a branch alias for dev-master which prevents this bundle from installing through composer. Remove this line to work around. 
+    The standard symfony 2.2 composer.json file has a branch alias that interferes with installing this bundle.  You can work around by removing the lines
+```
+ "branch-alias": {
+            "dev-master": "2.2-dev"
+        }
+``` 
 
 2) Modify your AppKernel with the following line:
 


### PR DESCRIPTION
There's not much there.  Current section was re-labeled Symfony 2.1, new section labeled Symfony 2.2.  
