### PR TITLE
Fix FileManager to use originals parameter instead of hard coded 'originals'

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -84,6 +84,7 @@ services:
         arguments:
           # For bc reasons we're not changing the names of the parameters
           - file_base_path: '%file_uploader.file_base_path%'
+            originals: '%file_uploader.originals%'
 
     punk_ave.twig.file_extension:
         class: PunkAve\FileUploaderBundle\Twig\FileExtension

--- a/Resources/public/js/FileUploader.js
+++ b/Resources/public/js/FileUploader.js
@@ -3,6 +3,7 @@ function PunkAveFileUploader(options)
   var self = this,
     uploadUrl = options.uploadUrl,
     viewUrl = options.viewUrl,
+    originalsDir = options.originalsDir || 'originals',
     $el = $(options.el),
     uploaderTemplate = _.template($.trim($('#file-uploader-template').html()));
   $el.html(uploaderTemplate({}));
@@ -10,9 +11,9 @@ function PunkAveFileUploader(options)
   var fileTemplate = _.template($.trim($('#file-uploader-file-template').html())),
     editor = $el.find('[data-files="1"]'),
     thumbnails = $el.find('[data-thumbnails="1"]');
-  
+
   self.uploading = false;
-  
+
   self.errorCallback = 'errorCallback' in options ? options.errorCallback : function( info ) { if (window.console && console.log) { console.log(info) } },
 
   self.addExistingFiles = function(files)
@@ -21,7 +22,7 @@ function PunkAveFileUploader(options)
       appendEditableImage({
         // cmsMediaUrl is a global variable set by the underscoreTemplates partial of MediaItems.html.twig
         'thumbnail_url': viewUrl + '/thumbnails/' + file,
-        'url': viewUrl + '/originals/' + file,
+        'url': viewUrl + '/' + originalsDir  + '/' + file,
         'name': file
         });
     });
@@ -119,7 +120,7 @@ function PunkAveFileUploader(options)
     var newAdditionalURL = "";
     var tempArray = url.split("?");
     var baseURL = tempArray[0];
-    var additionalURL = tempArray[1]; 
+    var additionalURL = tempArray[1];
     var temp = "";
     if (additionalURL)
     {

--- a/Services/FileManager.php
+++ b/Services/FileManager.php
@@ -12,7 +12,7 @@ class FileManager
     }
 
     /**
-     * Get a list of files already present. The 'folder' option is required. 
+     * Get a list of files already present. The 'folder' option is required.
      * If you pass consistent options to this method and handleFileUpload with
      * regard to paths, then you will get consistent results.
      */
@@ -20,10 +20,12 @@ class FileManager
     {
         $options = array_merge($this->options, $options);
 
+        $originals = $options['originals'];
+
         $folder = $options['file_base_path'] . '/' . $options['folder'];
         if (file_exists($folder))
         {
-            $dirs = glob("$folder/originals/*");
+            $dirs = glob($folder . '/' . $originals['folder'] . '/*');
             $fullPath = isset($options['full_path']) ? $options['full_path'] : false;
             if ($fullPath)
             {
@@ -68,11 +70,11 @@ class FileManager
     /**
      * Sync existing files from one folder to another. The 'fromFolder' and 'toFolder'
      * options are required. As with the 'folder' option elsewhere, these are appended
-     * to the file_base_path for you, missing parent folders are created, etc. If 
+     * to the file_base_path for you, missing parent folders are created, etc. If
      * 'fromFolder' does not exist no error is reported as this is common if no files
      * have been uploaded. If there are files and the sync reports errors an exception
      * is thrown.
-     * 
+     *
      * If you pass consistent options to this method and handleFileUpload with
      * regard to paths, then you will get consistent results.
      */


### PR DESCRIPTION
Originals was hard coded in FileManager. Make it use the parameter file_uploader.originals.folder

Fixes #25 
