### PR TITLE
Using basename() is not locale safe

### DIFF
--- a/Services/FileManager.php
+++ b/Services/FileManager.php
@@ -32,7 +32,7 @@ class FileManager
             if (!is_array($dirs)) {
                 $dirs = array();
             }
-            $result = array_map(function($s) { return basename($s); }, $dirs);
+            $result = array_map(function($s) { return preg_replace('|^.+[\\/]|', '', $s); }, $dirs);
             return $result;
         }
         else


### PR DESCRIPTION
Non-US-ASCII characters are stripped out of filenames. PHP's basename() does not properly support streams or filenames beginning with international characters.

example:
filename: "экрана от 2014-04-22 15:15:06.png" (russian, utf8),

basename stip it: "от 2014-04-22 15:15:06.png" (if not set locale by setlocale("ru_RU.UTF-8"))
