### PR TITLE
[*] Fixes: Added some missing new keywords and semicolons.

### DIFF
--- a/Resources/public/js/FileUploader.js
+++ b/Resources/public/js/FileUploader.js
@@ -52,7 +52,7 @@ function PunkAveFileUploader(options)
         attempt();
         return false;
     });
-  }
+  };
 
   if (options.blockFormWhileUploading)
   {

--- a/Services/FileManager.php
+++ b/Services/FileManager.php
@@ -79,21 +79,20 @@ class FileManager
     public function syncFiles($options = array())
     {
         $options = array_merge($this->options, $options);
-
         // We're syncing and potentially deleting folders, so make sure
         // we were passed something - make it a little harder to accidentally
         // trash your site
         if (!strlen(trim($options['file_base_path'])))
         {
-            throw \Exception("file_base_path option looks empty, bailing out");
+            throw new \Exception("file_base_path option looks empty, bailing out");
         }
         if (!strlen(trim($options['from_folder'])))
         {
-            throw \Exception("from_folder option looks empty, bailing out");
+            throw new \Exception("from_folder option looks empty, bailing out");
         }
         if (!strlen(trim($options['to_folder'])))
         {
-            throw \Exception("to_folder option looks empty, bailing out");
+            throw new \Exception("to_folder option looks empty, bailing out");
         }
 
         $from = $options['file_base_path'] . '/' . $options['from_folder'];

--- a/Services/FileUploader.php
+++ b/Services/FileUploader.php
@@ -111,6 +111,7 @@ class FileUploader
                 'image_versions' => $sizes,
                 'accept_file_types' => $allowedExtensionsRegex,
                 'max_number_of_files' => $options['max_number_of_files'],
+                'max_file_size' => $options['max_file_size'],
             ));
 
         // From https://github.com/blueimp/jQuery-File-Upload/blob/master/server/php/index.php


### PR DESCRIPTION
Fixed: Error in JS console while loading a view, with missing semicolon in  FileUploader.js.
Fixed: Fatal when reaching an exception (missing 'new' keyword) in FileManager.php.
Fixed: Missing 'max_file_size' option in FileUpload.php.