### PR TITLE
Fix problem with handle_file_upload arguments

### DIFF
--- a/BlueImp/UploadHandler.php
+++ b/BlueImp/UploadHandler.php
@@ -315,7 +315,7 @@ class UploadHandler
       	return $success;
     }
 
-    protected function handle_file_upload($uploaded_file, $name, $size, $type, $error, $index) {
+    protected function handle_file_upload($uploaded_file, $name, $size, $type, $error, $index=0) {
         $file = new \stdClass();
         $file->name = $this->trim_file_name($name, $type, $index);
         $file->size = intval($size);


### PR DESCRIPTION
in the file BlueImp/UploadHandler.php on line 412 set 5 arguments, but handle_file_upload takes 6.