### PR TITLE
Fix error with deleting all previous files

### DIFF
--- a/Services/FileManager.php
+++ b/Services/FileManager.php
@@ -108,7 +108,7 @@ class FileManager
                 throw new \Exception("to_folder does not exist");
             }
             $result = null;
-            system("rsync -a --delete " . escapeshellarg($from . '/') . " " . escapeshellarg($to), $result);
+            system("rsync -a " . escapeshellarg($from . '/') . " " . escapeshellarg($to), $result);
             if ($result !== 0)
             {
                 throw new \Exception("Sync failed with errorcode '$result'!");


### PR DESCRIPTION
I am facing a problem while adding new images. Old images that were previously in the folder were deleted. It was illogical, it was necessary to remove the **delete** flag in order to introduce logic into the code.